### PR TITLE
Relax httparty version dependency

### DIFF
--- a/hypdf.gemspec
+++ b/hypdf.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency "httparty", "~> 0.16.0"
+  gem.add_dependency "httparty", "> 0.16.0", "< 1.0"
   gem.add_development_dependency "rspec"
 end


### PR DESCRIPTION
I'm running into an issue getting to the latest httparty version (currently version 0.18.0). Can you relax the requirement and bump the gem version?