### PR TITLE
Adds a configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Ruby wrapper around the [HyPDF](https://www.hypdf.com) API
 
 Full documentation can be found [here](https://devcenter.heroku.com/articles/hypdf).
 
+## Configuration
+
+- `timeout` defaults to 60 (seconds)
+
+     HyPDF.configure {|c| c.timeout = 15 }
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Full documentation can be found [here](https://devcenter.heroku.com/articles/hyp
 
 - `timeout` defaults to 60 (seconds)
 
-     HyPDF.configure {|c| c.timeout = 15 }
+        HyPDF.configure {|c| c.timeout = 15 }
 
 ## Contributing
 

--- a/lib/hypdf.rb
+++ b/lib/hypdf.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'hypdf/config'
 require 'hypdf/exceptions'
 require 'hypdf/composite_io'
 require 'httparty'
@@ -153,8 +154,9 @@ class HyPDF
     def request(method, body)
       body[:user] ||= ENV["HYPDF_USER"]
       body[:password] ||= ENV["HYPDF_PASSWORD"]
+      timeout = HyPDF.config.timeout
 
-      response = HTTParty.post("#{HyPDF::HOST}/#{method}", body: body)
+      response = HTTParty.post("#{HyPDF::HOST}/#{method}", body: body, timeout: timeout)
       case response.code
       when 200 then response
       when 400 then raise HyPDF::ContentRequired

--- a/lib/hypdf/config.rb
+++ b/lib/hypdf/config.rb
@@ -1,0 +1,20 @@
+class HyPDF
+  class Config
+    attr_accessor :timeout
+    def initialize
+      @timeout = 60
+    end
+  end
+
+  class << self
+    attr_writer :config
+  end
+
+  def self.config
+    @config ||= Config.new
+  end
+
+  def self.configure
+    yield config
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe HyPDF::Config do
+  describe "Config#timeout" do
+    it 'will default to 60' do
+      expect(HyPDF.config.timeout).to eq 60
+    end
+
+    it 'can be changed to 5 seconds' do
+      HyPDF.configure {|c| c.timeout = 5 }
+      expect(HyPDF.config.timeout).to eq 5
+    end
+  end
+end


### PR DESCRIPTION
## Problem

I'd like to set a timeout for API calls to HyPDF, but it doesn't appear to be possible? This means I would need to wrap HyPDF calls in ruby's `Timeout` fn, but according to [this post](https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/), that's not ideal.

For example: 

```ruby
Timeout.timeout(5) { HyPDF.editmeta(...) }
```
## Changes
- Adds a [configuration pattern](https://simpleror.wordpress.com/2014/11/19/configuration-pattern-in-ruby/).
- Adds a timeout config option that defaults to 60 seconds.  Is 60 seconds a good default? I'm not really sure. Alternatively I could only pass a timeout if one is set.  

